### PR TITLE
CustomException, ExceptionHandler 구현

### DIFF
--- a/src/main/java/com/example/miniproject/constant/ErrorCode.java
+++ b/src/main/java/com/example/miniproject/constant/ErrorCode.java
@@ -1,0 +1,21 @@
+package com.example.miniproject.constant;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+	BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+	METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않은 메서드입니다."),
+	FORBIDDEN(HttpStatus.FORBIDDEN, "접근할 수 있는 권한이 없습니다."),
+	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "응답이 없습니다. 잠시 후 다시 시도해주세요."),
+	MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자 정보가 없습니다. 로그인 후 다시 시도해주세요."),
+	ANNUAL_NOT_FOUND(HttpStatus.NOT_FOUND, "연차/당직 정보가 없습니다."),
+	MEMBER_EMAIL_DUPLICATED(HttpStatus.BAD_REQUEST, "해당 이메일로 가입된 회원이 있습니다.");
+
+	private HttpStatus status;
+	private String message;
+}

--- a/src/main/java/com/example/miniproject/exception/AnnualException.java
+++ b/src/main/java/com/example/miniproject/exception/AnnualException.java
@@ -1,0 +1,17 @@
+package com.example.miniproject.exception;
+
+import com.example.miniproject.constant.ErrorCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AnnualException extends DomainException {
+
+	public AnnualException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/src/main/java/com/example/miniproject/exception/DomainException.java
+++ b/src/main/java/com/example/miniproject/exception/DomainException.java
@@ -1,0 +1,24 @@
+package com.example.miniproject.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.example.miniproject.constant.ErrorCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class DomainException extends RuntimeException {
+	private ErrorCode errorCode;
+	private HttpStatus httpStatus;
+	private String message;
+
+	public DomainException(ErrorCode errorCode) {
+		this.errorCode = errorCode;
+		this.httpStatus = errorCode.getStatus();
+		this.message = errorCode.getMessage();
+	}
+}

--- a/src/main/java/com/example/miniproject/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/miniproject/exception/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package com.example.miniproject.exception;
 
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import lombok.extern.slf4j.Slf4j;
@@ -7,5 +9,9 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
-	
+	@ExceptionHandler({MemberException.class, AnnualException.class})
+	public ResponseEntity<?> handlerMemberException(DomainException e) {
+		log.error(e.getMessage());
+		return ResponseEntity.status(e.getHttpStatus()).body(e.getMessage());
+	}
 }

--- a/src/main/java/com/example/miniproject/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/miniproject/exception/GlobalExceptionHandler.java
@@ -1,0 +1,11 @@
+package com.example.miniproject.exception;
+
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+	
+}

--- a/src/main/java/com/example/miniproject/exception/MemberException.java
+++ b/src/main/java/com/example/miniproject/exception/MemberException.java
@@ -1,0 +1,22 @@
+package com.example.miniproject.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com.example.miniproject.constant.ErrorCode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberException extends DomainException {
+	private ErrorCode errorCode;
+	private HttpStatus httpStatus;
+	private String message;
+
+	public MemberException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+}


### PR DESCRIPTION
### CustomException 생성

도메인을 기준으로 도메인별 CustomException 생성

- 연차/당직 관련 작업 중 예외 발생 시, AnnualException throw
- 회원 관련 작업 중 예외 발생 시, MemberException throw
- 관리자는 일단 보류하였음 (관리자 페이지에서도 결국 연차/당직, 회원 관련 작업이 발생하기 때문)