### PR TITLE
로그인 로그 기록 기능, 토큰 기능 리펙터링

### DIFF
--- a/src/main/java/com/example/miniproject/loginLog/domain/LoginLog.java
+++ b/src/main/java/com/example/miniproject/loginLog/domain/LoginLog.java
@@ -1,0 +1,30 @@
+package com.example.miniproject.loginLog.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class LoginLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String userAgent;
+
+    private String clientIp;
+
+    private LocalDateTime createdAt;
+
+}

--- a/src/main/java/com/example/miniproject/loginLog/dto/LoginLogDto.java
+++ b/src/main/java/com/example/miniproject/loginLog/dto/LoginLogDto.java
@@ -1,0 +1,34 @@
+package com.example.miniproject.loginLog.dto;
+
+import com.example.miniproject.loginLog.domain.LoginLog;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+public class LoginLogDto {
+
+    @Getter
+    @Builder
+    public static class CreateLoginLog {
+
+        private Long userId;
+
+        private String userAgent;
+
+        private String clientIp;
+
+        private LocalDateTime createdAt;
+
+        public LoginLog toEntity() {
+            return LoginLog.builder()
+                    .id(userId)
+                    .userAgent(userAgent)
+                    .clientIp(clientIp)
+                    .createdAt(createdAt)
+                    .build();
+        }
+
+    }
+
+}

--- a/src/main/java/com/example/miniproject/loginLog/repository/LoginLogRepository.java
+++ b/src/main/java/com/example/miniproject/loginLog/repository/LoginLogRepository.java
@@ -1,0 +1,9 @@
+package com.example.miniproject.loginLog.repository;
+
+import com.example.miniproject.loginLog.domain.LoginLog;
+import jakarta.persistence.Id;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LoginLogRepository extends JpaRepository<LoginLog, Id> {
+
+}

--- a/src/main/java/com/example/miniproject/loginLog/service/LoginLogService.java
+++ b/src/main/java/com/example/miniproject/loginLog/service/LoginLogService.java
@@ -1,0 +1,22 @@
+package com.example.miniproject.loginLog.service;
+
+import com.example.miniproject.loginLog.domain.LoginLog;
+import com.example.miniproject.loginLog.dto.LoginLogDto;
+import com.example.miniproject.loginLog.repository.LoginLogRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class LoginLogService {
+
+    private final LoginLogRepository loginLogRepository;
+
+    public void save(LoginLogDto.CreateLoginLog createLoginLog) {
+        LoginLog loginLog = createLoginLog.toEntity();
+        loginLogRepository.save(loginLog);
+    }
+
+}

--- a/src/main/java/com/example/miniproject/member/controller/MemberController.java
+++ b/src/main/java/com/example/miniproject/member/controller/MemberController.java
@@ -1,11 +1,21 @@
 package com.example.miniproject.member.controller;
 
+import com.example.miniproject.jwt.service.TokenService;
 import com.example.miniproject.member.dto.MemberRequestDto;
 import com.example.miniproject.member.service.MemberService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
 
 @RestController
 @RequiredArgsConstructor
@@ -13,6 +23,7 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController {
 
     private final MemberService memberService;
+    private final TokenService tokenService;
 
     @PostMapping("/register")
     public ResponseEntity<String> register(@RequestBody @Valid MemberRequestDto.CreateMember memberRequestDto) {
@@ -23,12 +34,26 @@ public class MemberController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<String> login(@RequestBody @Valid MemberRequestDto.LoginMember memberRequestDto) {
+    public ResponseEntity<String> login(
+            HttpServletRequest request,
+            Authentication authentication,
+            @RequestBody @Valid MemberRequestDto.LoginMember memberRequestDto
+    ) {
 
-        String token = memberService.login(memberRequestDto);
+        Map<String, String> tokens = memberService.login(request, memberRequestDto);
 
-        return ResponseEntity.ok().body(token);
+        ResponseCookie responseCookie = ResponseCookie.from(tokens.get("refreshToken"))
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .maxAge(60)
+                .sameSite("None")           // TODO : why use sameSite ?
+//                .domain("localhost:8080") // TODO : front-end domain
+                .build();
+
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
+                .body(tokens.get("refreshToken"));
     }
-
 
 }

--- a/src/main/java/com/example/miniproject/member/domain/RefreshToken.java
+++ b/src/main/java/com/example/miniproject/member/domain/RefreshToken.java
@@ -2,12 +2,12 @@ package com.example.miniproject.member.domain;
 
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @Entity
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RefreshToken {
 

--- a/src/main/java/com/example/miniproject/member/dto/MemberRequestDto.java
+++ b/src/main/java/com/example/miniproject/member/dto/MemberRequestDto.java
@@ -1,5 +1,6 @@
 package com.example.miniproject.member.dto;
 
+import com.example.miniproject.constant.Role;
 import com.example.miniproject.member.domain.Member;
 import com.example.miniproject.util.AESUtil;
 import jakarta.validation.constraints.Email;
@@ -38,6 +39,7 @@ public class MemberRequestDto {
                     .name(AESUtil.encrypt(name))
                     .email(AESUtil.encrypt(email))
                     .password(password)
+                    .role(Role.USER)
                     .joinedAt(join.atStartOfDay())
                     .build();
         }

--- a/src/main/java/com/example/miniproject/member/service/MemberService.java
+++ b/src/main/java/com/example/miniproject/member/service/MemberService.java
@@ -1,18 +1,26 @@
 package com.example.miniproject.member.service;
 
 import com.example.miniproject.jwt.service.JwtService;
+import com.example.miniproject.loginLog.dto.LoginLogDto;
+import com.example.miniproject.loginLog.service.LoginLogService;
 import com.example.miniproject.member.domain.Member;
+import com.example.miniproject.member.domain.RefreshToken;
 import com.example.miniproject.member.repository.MemberRepository;
+import com.example.miniproject.member.repository.RefreshTokenRepository;
 import com.example.miniproject.util.AESUtil;
 import jakarta.persistence.EntityNotFoundException;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 
-import static com.example.miniproject.member.dto.MemberRequestDto.*;
+import static com.example.miniproject.member.dto.MemberRequestDto.CreateMember;
+import static com.example.miniproject.member.dto.MemberRequestDto.LoginMember;
 
 @Service
 @Transactional
@@ -21,6 +29,10 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final JwtService jwtService;
+
+    private final LoginLogService loginLogService;
+
+    private final RefreshTokenRepository refreshTokenRepository;
     private final BCryptPasswordEncoder passwordEncoder;
 
     // 회원가입
@@ -31,25 +43,46 @@ public class MemberService {
         Member member = memberRequestDto.toEntity(
                 passwordEncoder.encode(memberRequestDto.getPassword())
         );
-
         memberRepository.save(member);
     }
 
     // 로그인
-    public String login(LoginMember memberRequestDto) {
+    public Map<String, String> login(HttpServletRequest request, LoginMember memberRequestDto) {
 
         // 회원이 존재하는지 검증
         Member member = memberRepository.findByEmail(AESUtil.encrypt(memberRequestDto.getEmail()))
                 .orElseThrow(() -> new EntityNotFoundException("존재하지 않는 회원입니다."));
 
         // 비밀번호가 일치하는지 검증
-        if(!passwordEncoder.matches(memberRequestDto.getPassword(), member.getPassword())) {
+        if (!passwordEncoder.matches(memberRequestDto.getPassword(), member.getPassword())) {
             throw new IllegalArgumentException("패스워드를 잘못 입력하였습니다.");
         }
 
-        String token = jwtService.generateToken(Duration.ofHours(1), member);
+        // accessToken TODO : Duration.ofHours
+        String accessToken = jwtService.generateToken(Duration.ofHours(1), member);
 
-        return token;
+        // refreshToken TODO : Duration.ofHours
+        String refreshToken = jwtService.generateToken(Duration.ofDays(1), member);
+
+        // save refreshToken
+        refreshTokenRepository.save(RefreshToken.builder()
+                .email(member.getEmail())
+                .refreshToken(refreshToken)
+                .build());
+
+        // loginLog save
+        loginLogService.save(LoginLogDto.CreateLoginLog.builder()
+                .userId(member.getId())
+                .userAgent(request.getHeader("User-Agent"))
+                .clientIp(request.getRemoteAddr())
+                .createdAt(member.getCreatedAt())
+                .build());
+
+        Map<String, String> map = new HashMap<>();
+        map.put("accessToken", accessToken);
+        map.put("refreshToken", refreshToken);
+
+        return map;
 
     }
 
@@ -63,7 +96,6 @@ public class MemberService {
         if (memberRepository.existsByEmail(email))
             throw new IllegalArgumentException("중복된 회원입니다.");
     }
-
 
 
 }


### PR DESCRIPTION
- #14 
- 로그인시 LoginLog 테이블이 저장하도록 설정하였다.
  - 문제점 : 원하던 clientIp 는 IPv4 형식인 ###.###.###.### 이지만 HttpServletRequest.getRemoteAddr 메서드를 사용하면 IPv6형식인 0:0:0:0:0:0:0:1 이 나온다. 
![image](https://github.com/seonghye0n/miniproject/assets/35757620/996803c6-9348-40de-95a5-060e6356d10a)
옵션을 주어야 하는데 설정 방법을 찾아봐야한다.

- refreshToken 을 어떠한 식으로 설정해야 하는지 의문 현재 코드에서는 refreshToken 도 accessToken 과 마찬가지로 JWT 형태임.  
![image](https://github.com/seonghye0n/miniproject/assets/35757620/47353619-e81e-4863-87c1-2f2ac6f3662d)
  - 생각한 방법은 DB 에 저장하는 RefreshToken 엔티티 객체에 PK 를 UUID 로 정해서 프론트단에게는 JWT 가 아닌 PK UUID 를 보내는 방법
  - 참고 블로그 : https://hudi.blog/refresh-token/ -

 

