### PR TITLE
#52 refactor: 회원 엔티티에 총 연차 수, 사용 연차수, 잔여 연차수 저장하도록 구조 변경 및 기능 추가

### DIFF
--- a/src/main/java/com/example/miniproject/member/domain/Member.java
+++ b/src/main/java/com/example/miniproject/member/domain/Member.java
@@ -14,6 +14,8 @@ import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PastOrPresent;
@@ -56,6 +58,13 @@ public class Member {
 
 	@UpdateTimestamp
 	private LocalDateTime modifiedAt;
+
+	@OneToOne()
+	@JoinColumn(name = "annual_amount_id")
+	private TotalAnnual totalAnnual;
+
+	private int annualUsed;
+	private int annualRemain;
 
 	public void changeName(String newName) {
 		this.name = newName;

--- a/src/main/java/com/example/miniproject/member/domain/TotalAnnual.java
+++ b/src/main/java/com/example/miniproject/member/domain/TotalAnnual.java
@@ -1,0 +1,23 @@
+package com.example.miniproject.member.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "annual")
+public class TotalAnnual {
+	@Id
+	private Long id;
+	private int years;
+	private int annualAmount;
+	private String histYear;
+}

--- a/src/main/java/com/example/miniproject/member/dto/MemberRequestDto.java
+++ b/src/main/java/com/example/miniproject/member/dto/MemberRequestDto.java
@@ -1,64 +1,69 @@
 package com.example.miniproject.member.dto;
 
+import java.time.LocalDate;
+
+import org.springframework.format.annotation.DateTimeFormat;
+
 import com.example.miniproject.constant.Role;
 import com.example.miniproject.member.domain.Member;
+import com.example.miniproject.member.domain.TotalAnnual;
 import com.example.miniproject.util.AESUtil;
+
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 import lombok.Getter;
-import org.springframework.format.annotation.DateTimeFormat;
-
-import java.time.LocalDate;
 
 public class MemberRequestDto {
 
-    @Getter
-    @Builder
-    public static class CreateMember {
+	@Getter
+	@Builder
+	public static class CreateMember {
 
-        @NotNull
-        private String name;
+		@NotNull
+		private String name;
 
-        @NotNull
-        @Email
-        private String email;
+		@NotNull
+		@Email
+		private String email;
 
-        @NotNull
-        @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[~!@#$%^&*()+|=])[A-Za-z\\d~!@#$%^&*()+|=]{8,16}$")
-        private String password;
+		@NotNull
+		@Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[~!@#$%^&*()+|=])[A-Za-z\\d~!@#$%^&*()+|=]{8,16}$")
+		private String password;
 
-        @NotNull
-        @DateTimeFormat(pattern = "yyyy-MM-dd")
-        private LocalDate join;
+		@NotNull
+		@DateTimeFormat(pattern = "yyyy-MM-dd")
+		private LocalDate join;
 
-        public Member toEntity(String password) {
+		public Member toEntity(String password, TotalAnnual totalAnnual) {
 
-            return Member.builder()
-                    .name(AESUtil.encrypt(name))
-                    .email(AESUtil.encrypt(email))
-                    .password(password)
-                    .role(Role.USER)
-                    .joinedAt(join.atStartOfDay())
-                    .build();
-        }
+			return Member.builder()
+				.name(AESUtil.encrypt(name))
+				.email(AESUtil.encrypt(email))
+				.password(password)
+				.role(Role.USER)
+				.joinedAt(join.atStartOfDay())
+				.totalAnnual(totalAnnual)
+				.annualUsed(0)
+				.annualRemain(totalAnnual.getAnnualAmount())
+				.build();
+		}
 
-    }
+	}
 
-    @Getter
-    @Builder
-    public static class LoginMember {
+	@Getter
+	@Builder
+	public static class LoginMember {
 
-        @NotNull
-        @Email
-        private String email;
+		@NotNull
+		@Email
+		private String email;
 
-        @NotNull
-        @Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[~!@#$%^&*()+|=])[A-Za-z\\d~!@#$%^&*()+|=]{8,16}$")
-        private String password;
+		@NotNull
+		@Pattern(regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[~!@#$%^&*()+|=])[A-Za-z\\d~!@#$%^&*()+|=]{8,16}$")
+		private String password;
 
-    }
-
+	}
 
 }

--- a/src/main/java/com/example/miniproject/member/repository/TotalAnnualRepository.java
+++ b/src/main/java/com/example/miniproject/member/repository/TotalAnnualRepository.java
@@ -1,0 +1,13 @@
+package com.example.miniproject.member.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import com.example.miniproject.member.domain.TotalAnnual;
+
+public interface TotalAnnualRepository extends JpaRepository<TotalAnnual, Long> {
+	@Query("SELECT t FROM TotalAnnual t WHERE t.years = (SELECT t2.years FROM TotalAnnual t2 WHERE t2.years <= :years)")
+	Optional<TotalAnnual> findAnnualAmountByYears(int years);
+}


### PR DESCRIPTION
### DB 작업
---
`Member`
annual_amount_id = annual.id
annual_used = 사용 연차수 -> 연차 등록, 삭제 시 update하도록 작업 예정
annual_remain = 잔여 연차수 -> used와 동일