### PR TITLE
Health Check URL 추가

### DIFF
--- a/src/main/java/com/example/miniproject/global/util/HealthCheckController.java
+++ b/src/main/java/com/example/miniproject/global/util/HealthCheckController.java
@@ -1,0 +1,14 @@
+package com.example.miniproject.global.util;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthCheckController {
+	@GetMapping("/")
+	public ResponseEntity<?> healthCheck() {
+		return ResponseEntity.ok().build();
+	}
+}


### PR DESCRIPTION
현재 AWS EC2 단일 인스턴스로 서버가 구성되어 있는데 단일 인스턴스는 Health Check URL을 변경 기능을 제공하지 않는 것으로 보임.

API 기능 중에 "/" 경로를 사용하는 것이 없어서 우선 해당 경로 GET 요청 시, 200 OK 응답하도록 추가함.